### PR TITLE
Move pg data bag definition to an attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,6 +10,8 @@ default['timesync']['group'] = 'timesync'
 default['timesync']['databag'] = 'timesync'
 default['timesync']['instance_name'] = 'timesync'
 
+default['timesync']['pg_info'] = 'pg'
+
 override['haproxy']['members'] = [
   {
     'hostname' => 'localhost',

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,7 +16,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-pg = Chef::EncryptedDataBagItem.load(node['timesync']['databag'], 'pg')
+pg = Chef::EncryptedDataBagItem.load(
+  node['timesync']['databag'],
+  node['timesync']['pg_info']
+)
+
 secret_key = Chef::EncryptedDataBagItem.load(node['timesync']['databag'], 'key')
 
 environment = {
@@ -56,4 +60,3 @@ pm2_application 'timesync' do
   user node['timesync']['user']
   action :start_or_graceful_reload
 end
-


### PR DESCRIPTION
This attribute makes it possible for the timesync-staging node to override which data bag item it uses for the postgres database access.
