### PR TITLE
Don't restart the application every time chef is run.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -62,4 +62,4 @@ end
 pm2_application 'timesync' do
   user node['timesync']['user']
   action :start
-  end
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -61,5 +61,5 @@ end
 
 pm2_application 'timesync' do
   user node['timesync']['user']
-  action :start_or_graceful_reload
-end
+  action :start
+  end


### PR DESCRIPTION
Will need another job to reload the application when there are new changes, but at the least, this is a good temporary fix for Chef unloading the auth tokens.
